### PR TITLE
Patch for gcc 10.2 and c++20

### DIFF
--- a/Server.cpp
+++ b/Server.cpp
@@ -22,7 +22,7 @@ struct Server::Pimpl {
 
     Epoll& m_epoll;
     Pimpl(Epoll& epoll) : m_epoll{epoll} {
-        m_epoll.addFD(stopFD, [=](int){ stopFD.get(); }, EPOLLIN|EPOLLET);
+        m_epoll.addFD(stopFD, [this](int){ stopFD.get(); }, EPOLLIN|EPOLLET);
     }
 
     ~Pimpl() {
@@ -36,7 +36,7 @@ struct Server::Pimpl {
         for (auto const& host : hosts) {
             auto& ss = server_sockets.emplace_back(host);
             int ss_fd = ss;
-            m_epoll.addFD(ss_fd, [=, &ss](int flags) {
+            m_epoll.addFD(ss_fd, [this, &ss](int flags) {
                 if (flags != EPOLLIN) {
                     m_epoll.rmFD(ss, false);
                     return;

--- a/base64.h
+++ b/base64.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 #include <string_view>
 #include <vector>
 


### PR DESCRIPTION
gcc 10.2 has reshuffled its standard library headers.
This adds a missing include.

Also it remove deprecate warnings for c++20.
This still compiles for c++17 and c++20